### PR TITLE
Use '<SchedulerId>:<TaskId>' as key to avoid message partition issue

### DIFF
--- a/pkg/scheduler/eventmanager.go
+++ b/pkg/scheduler/eventmanager.go
@@ -183,7 +183,7 @@ func (m *EventManager) Iterate(tenantId, taskId string, fn func(e *TaskEvent) bo
 
 		task := tenant.Bucket([]byte(taskId))
 		if task == nil {
-			m.lg.Log(types.LevelWarn, "taskId", taskId, "message", "task db is empty")
+			// m.lg.Log(types.LevelInfo, "taskId", taskId, "message", "task db is empty (can be ignored)")
 			return nil
 		}
 

--- a/pkg/worker/main.go
+++ b/pkg/worker/main.go
@@ -256,8 +256,8 @@ func (w *Worker) notify(m *types.TaskMessage) {
 		return
 	}
 
-	// Use '<SchedulerId>:<TenantId>' as key to avoid message partition issue
-	key := fmt.Sprintf("%s:%s", m.SchedulerId, m.Task.TenantId)
+	// Use '<SchedulerId>:<TaskId>' as key to avoid message partition issue
+	key := fmt.Sprintf("%s:%s", m.SchedulerId, m.Task.Uid)
 	if err = w.tran.Send(w.info.Id, key, byt); err != nil {
 		w.lg.Log(types.LevelError, "error", err.Error(),
 			"workerId", w.info.Id, "schedulerId", m.SchedulerId, "tenantId", m.Task.TenantId,


### PR DESCRIPTION
Use '<SchedulerId>:<TaskId>' as key to avoid message partition issue